### PR TITLE
Pipeline fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,14 +29,14 @@ stages:
       vmImage: 'ubuntu-latest'
     strategy:
       matrix:
-        py3.5:
-          PYTHON_VERSION: '3.5'
         py3.6:
           PYTHON_VERSION: '3.6'
         py3.7:
           PYTHON_VERSION: '3.7'
         py3.8:
           PYTHON_VERSION: '3.8'
+        py3.9:
+          PYTHON_VERSION: '3.9'
 
     steps:
     - task: UsePythonVersion@0
@@ -80,7 +80,7 @@ stages:
     - task: UsePythonVersion@0
       displayName: 'Use Python version'
       inputs:
-        versionSpec: '3.8'
+        versionSpec: '3.9'
         architecture: 'x64'
 
     - script: python -m pip install -r requirements-dev.txt

--- a/ci/compare-codecov.ps1
+++ b/ci/compare-codecov.ps1
@@ -26,7 +26,7 @@ with multiple pipelines.
 param(
     [string] $wd = (Get-Item (Split-Path $PSCommandPath -Parent)).Parent,
     [string] $org = "coderedcorp",
-    [string] $project = "coderedcms",
+    [string] $project = "cr-github",
     [string] $pipeline_name = "django-sass"
 )
 

--- a/django_sass/__init__.py
+++ b/django_sass/__init__.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 import os
 
 from django.contrib.staticfiles.finders import get_finders
-import sass 
+import sass
 
 
 def find_static_paths() -> List[str]:

--- a/django_sass/__init__.py
+++ b/django_sass/__init__.py
@@ -96,7 +96,7 @@ def compile_sass(inpath: str, outpath: str, output_style: str = None, precision:
         output_style=output_style,
         precision=precision,
         include_paths=include_paths,
-        **sassargs,      
+        **sassargs,
     )
 
     # Write output.

--- a/django_sass/__init__.py
+++ b/django_sass/__init__.py
@@ -2,7 +2,8 @@ from typing import Dict, List
 import os
 
 from django.contrib.staticfiles.finders import get_finders
-import sass
+import libsass
+from libsass import sass as sass
 
 
 def find_static_paths() -> List[str]:
@@ -96,7 +97,7 @@ def compile_sass(inpath: str, outpath: str, output_style: str = None, precision:
         output_style=output_style,
         precision=precision,
         include_paths=include_paths,
-        **sassargs,
+        **sassargs,       
     )
 
     # Write output.

--- a/django_sass/__init__.py
+++ b/django_sass/__init__.py
@@ -2,8 +2,7 @@ from typing import Dict, List
 import os
 
 from django.contrib.staticfiles.finders import get_finders
-import libsass
-from libsass import sass as sass
+import sass 
 
 
 def find_static_paths() -> List[str]:

--- a/django_sass/__init__.py
+++ b/django_sass/__init__.py
@@ -96,7 +96,7 @@ def compile_sass(inpath: str, outpath: str, output_style: str = None, precision:
         output_style=output_style,
         precision=precision,
         include_paths=include_paths,
-        **sassargs,       
+        **sassargs,      
     )
 
     # Write output.

--- a/django_sass/management/commands/sass.py
+++ b/django_sass/management/commands/sass.py
@@ -1,8 +1,7 @@
+from typing import Dict
 import os
 import sys
 import time
-
-from typing import Dict
 
 from django.core.management.base import BaseCommand
 import sass

--- a/django_sass/management/commands/sass.py
+++ b/django_sass/management/commands/sass.py
@@ -5,8 +5,7 @@ import time
 from typing import Dict
 
 from django.core.management.base import BaseCommand
-import libsass
-from libsass import sass as sass
+import sass
 
 from django_sass import compile_sass, find_static_scss
 

--- a/django_sass/management/commands/sass.py
+++ b/django_sass/management/commands/sass.py
@@ -73,7 +73,7 @@ class Command(BaseCommand):
                 self.stdout.write("Watching...")
 
                 # Track list of files to watch and their modified time.
-                watchfiles = {} # type: Dict[str, object]
+                watchfiles = {} # type: Dict[str, float]
                 while True:
                     needs_updated = False
 

--- a/django_sass/management/commands/sass.py
+++ b/django_sass/management/commands/sass.py
@@ -73,7 +73,7 @@ class Command(BaseCommand):
                 self.stdout.write("Watching...")
 
                 # Track list of files to watch and their modified time.
-                watchfiles = {} # type: Dict[str, float]
+                watchfiles = {}  # type: Dict[str, float]
                 while True:
                     needs_updated = False
 

--- a/django_sass/management/commands/sass.py
+++ b/django_sass/management/commands/sass.py
@@ -2,8 +2,11 @@ import os
 import sys
 import time
 
+from typing import Dict
+
 from django.core.management.base import BaseCommand
-import sass
+import libsass
+from libsass import sass as sass
 
 from django_sass import compile_sass, find_static_scss
 
@@ -71,7 +74,7 @@ class Command(BaseCommand):
                 self.stdout.write("Watching...")
 
                 # Track list of files to watch and their modified time.
-                watchfiles = {}
+                watchfiles = {} # type: Dict[str, object]
                 while True:
                     needs_updated = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ exclude = migrations
 
 [mypy]
 ignore_missing_imports = True
+namespace_packages = True
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = testproject.settings

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "django",
-        "libsass"
+        "libsass",
     ],
     classifiers=[
         "Intended Audience :: Developers",

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+from typing import List
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -25,7 +26,7 @@ SECRET_KEY = '-_wl=tq26(*wyvfza+ncg_436c53pu81d=07j62+vm5y2pc)f^'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS: List[str] = []
 
 
 # Application definition

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = '-_wl=tq26(*wyvfza+ncg_436c53pu81d=07j62+vm5y2pc)f^'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = [] # type: List[str]
+ALLOWED_HOSTS = []  # type: List[str]
 
 
 # Application definition

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = '-_wl=tq26(*wyvfza+ncg_436c53pu81d=07j62+vm5y2pc)f^'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS: List[str] = []
+ALLOWED_HOSTS = [] # type: List[str]
 
 
 # Application definition

--- a/testproject/tests.py
+++ b/testproject/tests.py
@@ -93,7 +93,7 @@ class TestDjangoSass(unittest.TestCase):
         self.assert_output(outpath)
         self.assertTrue(os.path.isfile(os.path.join(self.outdir, "test.css.map")))
 
-    @unittest.skip
+    @unittest.skip("Test needs fixed...")
     def test_cli_watch(self):
         # Input and output paths relative to django static dirs.
         inpath = os.path.join("app2", "static", "app2", "scss", "test.scss")


### PR DESCRIPTION
1) Fixed mypy typing errors and package finding error 

20) Still working on pytest failures, which seem to be result of not recognizing python path or environment variables correctly. The 3 cli tests fail, use manage.py in a command, this is the error [file paths redacted]:

Traceback (most recent call last):
  File "****\testproject\manage.py", line 10, in main
    from django.core.management import execute_from_command_line
ModuleNotFoundError: No module named 'django'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "***\django-sass\testproject\manage.py", line 21, in <module>
    main()
  File "**** \testproject\manage.py", line 12, in main
    raise ImportError(
ImportError: Couldn't import Django. Are you sure it's installed and available on your PYTHONPATH environment variable? Did you forget to activate a virtual environment?

I tried it in different python and django versions as well as different pytest-django and pytest versions and still get the error. EDIT: pytest all passes in the actual pipeline so not sure why it's failing when I run it locally. Maybe something with my virtual environment and not within the code itself??