### PR TITLE
Add support for indent-style syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,6 @@ Limitations
   @import '../file';
   ```
 
-* Only files ending in `.scss` are supported for now.
-
 * Only supports `-g`, `-p`, and `-t` options similar to `pysassc`. Ideally
   `django-sass` will be as similar as possible to the `pysassc` command line
   interface.
@@ -261,6 +259,9 @@ Then run the unit tests:
 
 Changelog
 ---------
+
+#### 1.1.0
+* New: Will now compile Sass files as well as SCSS files.
 
 #### 1.0.1
 * Maintanence release, no functional changes.

--- a/django_sass/__init__.py
+++ b/django_sass/__init__.py
@@ -24,15 +24,15 @@ def find_static_paths() -> List[str]:
 
 def find_static_scss() -> List[str]:
     """
-    Finds all static scss files available in this Django project.
+    Finds all static scss/sass files available in this Django project.
 
     :returns:
-        List of paths of static scss files.
+        List of paths of static scss/sass files.
     """
     scss_files = []
     for finder in get_finders():
         for path, storage in finder.list([]):
-            if path.endswith(".scss"):
+            if path.endswith(".scss") or path.endswith(".sass"):
                 fullpath = finder.find(path)
                 scss_files.append(fullpath)
     return scss_files
@@ -51,7 +51,7 @@ def compile_sass(
     and writes output CSS and/or sourcemaps to file.
 
     :param str inpath:
-        Path to SCSS file or directory of SCSS files.
+        Path to SCSS/Sass file or directory of SCSS/Sass files.
     :param str outpath:
         Path to a CSS file or directory in which to write output. The path will
         be created if it does not exist.
@@ -90,7 +90,10 @@ def compile_sass(
         sassargs.update({"filename": inpath})
         if os.path.isdir(outpath):
             outfile = os.path.join(
-                outpath, os.path.basename(inpath.replace(".scss", ".css"))
+                outpath,
+                os.path.basename(
+                    inpath.replace(".scss", ".css").replace(".sass", ".css")
+                ),
             )
         else:
             outfile = outpath

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(
 
 setup(
     name="django-sass",
-    version="1.0.1",
+    version="1.1.0",
     author="CodeRed LLC",
     author_email="info@coderedcorp.com",
     url="https://github.com/coderedcorp/django-sass",

--- a/testproject/app3/apps.py
+++ b/testproject/app3/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class App3Config(AppConfig):
+    name = "app3"

--- a/testproject/app3/static/app3/sass/indent_test.sass
+++ b/testproject/app3/static/app3/sass/indent_test.sass
@@ -1,0 +1,4 @@
+/* Tests: app3/sass/indent_test.sass */
+
+.test_item
+    border: 1px solid red

--- a/testproject/app3/static/app3/sass/test.sass
+++ b/testproject/app3/static/app3/sass/test.sass
@@ -1,0 +1,2 @@
+.test_item
+    border: 1px solid red

--- a/testproject/app3/static/app3/sass/test.sass
+++ b/testproject/app3/static/app3/sass/test.sass
@@ -1,2 +1,0 @@
-.test_item
-    border: 1px solid red

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -34,6 +34,7 @@ ALLOWED_HOSTS = []  # type: List[str]
 INSTALLED_APPS = [
     "app1",
     "app2",
+    "app3",
     "django_sass",
     "django.contrib.admin",
     "django.contrib.auth",

--- a/testproject/tests.py
+++ b/testproject/tests.py
@@ -72,6 +72,12 @@ class TestDjangoSass(unittest.TestCase):
             )
             in files
         )
+        self.assertTrue(
+            os.path.join(
+                THIS_DIR, "app3", "static", "app3", "sass", "test.sass"
+            )
+            in files
+        )
 
     def test_cli(self):
         # Input and output paths relative to django static dirs.

--- a/testproject/tests.py
+++ b/testproject/tests.py
@@ -3,11 +3,19 @@ import shutil
 import subprocess
 import time
 import unittest
+from typing import List
 
 from django_sass import find_static_paths, find_static_scss
 
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+SCSS_CONTAINS = [
+    "/* Tests: app1/scss/_include.scss */",
+    "/* Tests: app2/scss/_samedir.scss */",
+    "/* Tests: app2/scss/subdir/_subdir.scss */",
+    "/* Tests: app2/scss/test.scss */",
+]
 
 
 class TestDjangoSass(unittest.TestCase):
@@ -18,20 +26,29 @@ class TestDjangoSass(unittest.TestCase):
         # Clean up output files
         shutil.rmtree(self.outdir, ignore_errors=True)
 
-    def assert_output(self, real_outpath: str):
+    def assert_output(
+        self,
+        inpath: str,
+        outpath: str,
+        real_outpath: str,
+        contains: List[str],
+        args: List[str] = None,
+    ):
+        # Command to run
+        args = args or []
+        cmd = ["python", "manage.py", "sass", *args, inpath, outpath]
+        # Run the management command on testproject.
+        proc = subprocess.run(cmd, cwd=THIS_DIR)
+        # Verify the process exited cleanly.
+        self.assertEqual(proc.returncode, 0)
         # Verify that the output file exists.
-        print(real_outpath)
-        self.assertTrue(os.path.isfile(real_outpath))
+        # self.assertTrue(os.path.isfile(real_outpath))
 
         # Verify that the file contains expected output from all sass files.
         with open(real_outpath, encoding="utf8") as f:
             contents = f.read()
-            self.assertTrue("/* Tests: app1/scss/_include.scss */" in contents)
-            self.assertTrue("/* Tests: app2/scss/_samedir.scss */" in contents)
-            self.assertTrue(
-                "/* Tests: app2/scss/subdir/_subdir.scss */" in contents
-            )
-            self.assertTrue("/* Tests: app2/scss/test.scss */" in contents)
+            for compiled_data in contains:
+                self.assertTrue(compiled_data in contents)
 
     def test_find_static_paths(self):
         paths = find_static_paths()
@@ -74,7 +91,7 @@ class TestDjangoSass(unittest.TestCase):
         )
         self.assertTrue(
             os.path.join(
-                THIS_DIR, "app3", "static", "app3", "sass", "test.sass"
+                THIS_DIR, "app3", "static", "app3", "sass", "indent_test.sass"
             )
             in files
         )
@@ -83,42 +100,48 @@ class TestDjangoSass(unittest.TestCase):
         # Input and output paths relative to django static dirs.
         inpath = os.path.join("app2", "static", "app2", "scss", "test.scss")
         outpath = os.path.join(self.outdir, "test_file.css")
-        # Command to run
-        cmd = ["python", "manage.py", "sass", inpath, outpath]
-        # Run the management command on testproject.
-        proc = subprocess.run(cmd, cwd=THIS_DIR)
-        # Verify the process exited cleanly.
-        self.assertEqual(proc.returncode, 0)
-        # Assert output is correct.
-        self.assert_output(outpath)
+        self.assert_output(
+            inpath=inpath,
+            outpath=outpath,
+            real_outpath=outpath,
+            contains=SCSS_CONTAINS,
+        )
 
     def test_cli_dir(self):
         # Input and output paths relative to django static dirs.
         inpath = os.path.join("app2", "static", "app2", "scss")
-        outpath = self.outdir
         # Expected output path on filesystem.
         real_outpath = os.path.join(self.outdir, "test.css")
-        # Command to run
-        cmd = ["python", "manage.py", "sass", inpath, outpath]
-        # Run the management command on testproject.
-        proc = subprocess.run(cmd, cwd=THIS_DIR)
-        # Verify the process exited cleanly.
-        self.assertEqual(proc.returncode, 0)
-        # Assert output is correct.
-        self.assert_output(real_outpath)
+        self.assert_output(
+            inpath=inpath,
+            outpath=self.outdir,
+            real_outpath=real_outpath,
+            contains=SCSS_CONTAINS,
+        )
+
+    def test_sass_compiles(self):
+        # Input and output paths relative to django static dirs.
+        inpath = os.path.join("app3", "static", "app3", "sass")
+        # Expected output path on filesystem.
+        real_outpath = os.path.join(self.outdir, "indent_test.css")
+        self.assert_output(
+            inpath=inpath,
+            outpath=self.outdir,
+            real_outpath=real_outpath,
+            contains=["/* Tests: app3/sass/indent_test.sass */"],
+        )
 
     def test_cli_srcmap(self):
         # Input and output paths relative to django static dirs.
         inpath = os.path.join("app2", "static", "app2", "scss", "test.scss")
         outpath = os.path.join(self.outdir, "test.css")
-        # Command to run
-        cmd = ["python", "manage.py", "sass", "-g", inpath, outpath]
-        # Run the management command on testproject.
-        proc = subprocess.run(cmd, cwd=THIS_DIR)
-        # Verify the process exited cleanly.
-        self.assertEqual(proc.returncode, 0)
-        # Assert output is correct.
-        self.assert_output(outpath)
+        self.assert_output(
+            inpath=inpath,
+            outpath=outpath,
+            real_outpath=outpath,
+            contains=SCSS_CONTAINS,
+            args=["-g"],
+        )
         self.assertTrue(
             os.path.isfile(os.path.join(self.outdir, "test.css.map"))
         )


### PR DESCRIPTION
This is very simple because libsass-python already supports this and even detects when to use it.