### PR TITLE
If outpath does not exist and appears to be a dir, create it

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ Changelog
 ---------
 
 #### 1.1.0
-* New: Will now compile Sass files as well as SCSS files.
+* New: Now compiles `.sass` files as well as `.scss` files.
+* Fix bug when input path is a file and output path does not exist.
 
 #### 1.0.1
 * Maintanence release, no functional changes.

--- a/django_sass/__init__.py
+++ b/django_sass/__init__.py
@@ -87,8 +87,17 @@ def compile_sass(
     # Handle input files.
     outfile = None
     if os.path.isfile(inpath):
+
         sassargs.update({"filename": inpath})
-        if os.path.isdir(outpath):
+
+        # If outpath does not exist, guess if it should be a dir and create it.
+        if not os.path.exists(outpath):
+            if not (outpath.endswith(".scss") or outpath.endswith(".sass")):
+                os.makedirs(outpath)
+
+        # If outpath is a directory, create a child file.
+        # Otherwise use provided file path.
+        if os.path.exists(outpath) and os.path.isdir(outpath):
             outfile = os.path.join(
                 outpath,
                 os.path.basename(
@@ -97,6 +106,8 @@ def compile_sass(
             )
         else:
             outfile = outpath
+
+        # Create source map if specified.
         if source_map:
             sassargs.update({"source_map_filename": outfile + ".map"})
 

--- a/django_sass/__init__.py
+++ b/django_sass/__init__.py
@@ -92,7 +92,7 @@ def compile_sass(
 
         # If outpath does not exist, guess if it should be a dir and create it.
         if not os.path.exists(outpath):
-            if not (outpath.endswith(".scss") or outpath.endswith(".sass")):
+            if not outpath.endswith(".css"):
                 os.makedirs(outpath)
 
         # If outpath is a directory, create a child file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ target-version = ['py36', 'py37', 'py38']
 # Regular expression of files to exclude.
 exclude = '''
 /(
-    migrations
+    .venv
+    | venv
+    | migrations
 )/
 '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 100
-exclude = migrations
+exclude = .venv,venv,migrations
 
 [mypy]
 ignore_missing_imports = True

--- a/testproject/tests.py
+++ b/testproject/tests.py
@@ -119,6 +119,19 @@ class TestDjangoSass(unittest.TestCase):
             contains=SCSS_CONTAINS,
         )
 
+    def test_cli_infile_outdir(self):
+        # Input is a file; output is non-existant path (without .css extension).
+        inpath = os.path.join("app2", "static", "app2", "scss", "test.scss")
+        outpath = os.path.join(self.outdir, "does-not-exist")
+        # Expected output path on filesystem.
+        real_outpath = os.path.join(outpath, "test.css")
+        self.assert_output(
+            inpath=inpath,
+            outpath=outpath,
+            real_outpath=real_outpath,
+            contains=SCSS_CONTAINS,
+        )
+
     def test_sass_compiles(self):
         # Input and output paths relative to django static dirs.
         inpath = os.path.join("app3", "static", "app3", "sass")


### PR DESCRIPTION
If the user specifies an input file, but output path that does not exist, the program currently crashes trying to check if the output path is a directory.

In this situation, first check if the output path exists, if not, guess if it should be a directory or file, and create it if necessary.